### PR TITLE
Refactor controller and config with constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# kougeki
+# Kougeki
+
+Simple GUI tool for analyzing text aggressiveness using OpenAI API.
+The application loads an Excel file, sends each row to the moderation
+and chat endpoints asynchronously, and writes the results back.
+
+## Requirements
+
+- Python 3.11+
+- OpenAI API key in `.env`
+
+Run `python main.py` to start the GUI.

--- a/kougeki/config.py
+++ b/kougeki/config.py
@@ -1,16 +1,16 @@
-import os
-from dataclasses import dataclass
+"""Application configuration using :mod:`pydantic` settings."""
 
-from dotenv import load_dotenv
-
-load_dotenv()
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-@dataclass(slots=True)
-class Settings:
-    openai_api_key: str = os.getenv("OPENAI_API_KEY", "")
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment or ``.env``."""
+
+    openai_api_key: str = ""
     chat_model: str = "gpt-4.1-mini-2025-04-14"
     moderation_model: str = "omni-moderation-latest"
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
     @property
     def is_configured(self) -> bool:

--- a/kougeki/constants.py
+++ b/kougeki/constants.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Application constants used throughout the project."""
+
+CATEGORY_NAMES = [
+    "hate",
+    "hate/threatening",
+    "self-harm",
+    "sexual",
+    "sexual/minors",
+    "violence",
+    "violence/graphic",
+]
+
+STATUS_COLORS = {
+    "default": "white",
+    "error": "red",
+    "success": "green",
+}

--- a/kougeki/controller.py
+++ b/kougeki/controller.py
@@ -5,12 +5,15 @@ from tkinter import filedialog, messagebox
 import pandas as pd
 
 from . import services
-from .models import AggressivenessResult, ModerationResult
+from .constants import CATEGORY_NAMES, STATUS_COLORS
+
 
 logger = logging.getLogger(__name__)
 
 
 class ModerationController:
+    """Handle user actions and orchestrate moderation services."""
+
     def __init__(self, view):
         self.view = view
         self.df: pd.DataFrame | None = None
@@ -22,12 +25,16 @@ class ModerationController:
         try:
             self.df = pd.read_excel(file_path, sheet_name=0)
             self.view.update_status(
-                f"ファイルを読み込みました: {len(self.df)}件のデータ", "green"
+                f"ファイルを読み込みました: {len(self.df)}件のデータ",
+                STATUS_COLORS["success"],
             )
             self.view.enable_analyze(True)
         except Exception as exc:  # noqa: BLE001
             logger.exception("failed to load excel")
-            self.view.update_status("ファイルの読み込みに失敗しました", "red")
+            self.view.update_status(
+                "ファイルの読み込みに失敗しました",
+                STATUS_COLORS["error"],
+            )
             messagebox.showerror(
                 "読み込みエラー", f"ファイルを読み込めませんでした: {exc}"
             )
@@ -42,10 +49,12 @@ class ModerationController:
             return
         try:
             self.df.to_excel(save_path, index=False)
-            self.view.update_status("結果を保存しました", "green")
+            self.view.update_status(
+                "結果を保存しました", STATUS_COLORS["success"]
+            )
         except Exception as exc:  # noqa: BLE001
             logger.exception("failed to save excel")
-            self.view.update_status("保存に失敗しました", "red")
+            self.view.update_status("保存に失敗しました", STATUS_COLORS["error"]) 
             messagebox.showerror("保存エラー", f"ファイルを保存できませんでした: {exc}")
 
     def analyze_file_sync(self):
@@ -53,29 +62,24 @@ class ModerationController:
 
     async def _analyze_file(self):
         if self.df is None or "投稿内容" not in self.df.columns:
-            self.view.update_status("「投稿内容」列が見つかりません", "red")
+            self.view.update_status(
+                "「投稿内容」列が見つかりません", STATUS_COLORS["error"]
+            )
             return
         self.view.enable_buttons(False)
         total_rows = len(self.df)
-        category_names = [
-            "hate",
-            "hate/threatening",
-            "self-harm",
-            "sexual",
-            "sexual/minors",
-            "violence",
-            "violence/graphic",
-        ]
-        category_flags = {name: [] for name in category_names}
-        category_scores = {name: [] for name in category_names}
+        category_flags = {name: [] for name in CATEGORY_NAMES}
+        category_scores = {name: [] for name in CATEGORY_NAMES}
         ag_scores: list[int | None] = []
         ag_reasons: list[str | None] = []
         for idx, row in self.df.iterrows():
             text = row["投稿内容"]
-            mod_res: ModerationResult = await services.moderate_text(text)
-            ag_res: AggressivenessResult = await services.get_aggressiveness_score(text)
+            mod_res, ag_res = await asyncio.gather(
+                services.moderate_text(text),
+                services.get_aggressiveness_score(text),
+            )
 
-            for name in category_names:
+            for name in CATEGORY_NAMES:
                 attr = name.replace("/", "_")
                 category_flags[name].append(getattr(mod_res.categories, attr))
                 category_scores[name].append(getattr(mod_res.scores, attr))
@@ -88,10 +92,12 @@ class ModerationController:
             self.view.update_status(f"分析中... {idx + 1}/{total_rows}")
             await asyncio.sleep(0)  # allow UI update
 
-        for name in category_names:
+        for name in CATEGORY_NAMES:
             self.df[f"{name}_flag"] = category_flags[name]
             self.df[f"{name}_score"] = category_scores[name]
         self.df["aggressiveness_score"] = ag_scores
         self.df["aggressiveness_reason"] = ag_reasons
-        self.view.update_status("分析が完了しました", "green")
+        self.view.update_status(
+            "分析が完了しました", STATUS_COLORS["success"]
+        )
         self.view.enable_buttons(True)

--- a/kougeki/services.py
+++ b/kougeki/services.py
@@ -1,3 +1,5 @@
+"""Async service layer for calling the OpenAI API."""
+
 import asyncio
 import logging
 from functools import wraps

--- a/kougeki/view.py
+++ b/kougeki/view.py
@@ -1,5 +1,6 @@
 import customtkinter as ctk
 
+from .constants import STATUS_COLORS
 from .controller import ModerationController
 
 ctk.set_appearance_mode("dark")
@@ -7,6 +8,8 @@ ctk.set_default_color_theme("blue")
 
 
 class ModerationView(ctk.CTk):
+    """Tkinter GUI for moderating text in Excel files."""
+
     def __init__(self):
         super().__init__()
         self.controller = ModerationController(self)
@@ -68,7 +71,7 @@ class ModerationView(ctk.CTk):
         self.progress_bar.pack(pady=20)
         self.progress_bar.set(0)
 
-    def update_status(self, text: str, color: str = "white"):
+    def update_status(self, text: str, color: str = STATUS_COLORS["default"]):
         self.status_label.configure(text=text, text_color=color)
 
     def update_progress(self, value: float):


### PR DESCRIPTION
## Summary
- use pydantic-settings for configuration
- centralize category names and UI colors in `constants.py`
- update controller to use new constants and run requests concurrently
- tweak view to reference color constants
- add basic README

## Testing
- `ruff check .`
- `python -m compileall -q kougeki main.py`


------
https://chatgpt.com/codex/tasks/task_e_686bc31b50508333878b99e634e3a115