### PR TITLE
Add tests and CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ and chat endpoints asynchronously, and writes the results back.
 - OpenAI API key in `.env`
 
 Run `python main.py` to start the GUI.
+
+## Running Tests
+
+Install test dependencies and execute the suite:
+
+```bash
+python -m pip install -r requirements.txt
+pytest -q
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+openai
+pydantic-settings
+pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- add unit tests for service layer and retry decorator
- document how to run tests
- include requirements file
- run tests in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc79d9f1083338b0f7fdeaa017317