### PR TITLE
Implement threaded async analysis

### DIFF
--- a/kougeki/controller.py
+++ b/kougeki/controller.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import threading
 from tkinter import filedialog, messagebox
 
 import pandas as pd
@@ -18,20 +19,35 @@ class ModerationController:
         self.view = view
         self.df: pd.DataFrame | None = None
 
+    # ------------------------------------------------------------------
+    # Helper methods for thread-safe GUI updates
+    # ------------------------------------------------------------------
+    def _call_view(self, func, *args, **kwargs) -> None:
+        self.view.call_in_main(func, *args, **kwargs)
+
+    def _update_status(self, text: str, color: str = STATUS_COLORS["default"]) -> None:
+        self._call_view(self.view.update_status, text, color)
+
+    def _update_progress(self, value: float) -> None:
+        self._call_view(self.view.update_progress, value)
+
+    def _enable_buttons(self, enable: bool) -> None:
+        self._call_view(self.view.enable_buttons, enable)
+
     def load_excel_file(self):
         file_path = filedialog.askopenfilename(filetypes=[("Excel files", "*.xlsx")])
         if not file_path:
             return
         try:
             self.df = pd.read_excel(file_path, sheet_name=0)
-            self.view.update_status(
+            self._update_status(
                 f"ファイルを読み込みました: {len(self.df)}件のデータ",
                 STATUS_COLORS["success"],
             )
-            self.view.enable_analyze(True)
+            self._call_view(self.view.enable_analyze, True)
         except Exception as exc:  # noqa: BLE001
             logger.exception("failed to load excel")
-            self.view.update_status(
+            self._update_status(
                 "ファイルの読み込みに失敗しました",
                 STATUS_COLORS["error"],
             )
@@ -49,24 +65,27 @@ class ModerationController:
             return
         try:
             self.df.to_excel(save_path, index=False)
-            self.view.update_status(
+            self._update_status(
                 "結果を保存しました", STATUS_COLORS["success"]
             )
         except Exception as exc:  # noqa: BLE001
             logger.exception("failed to save excel")
-            self.view.update_status("保存に失敗しました", STATUS_COLORS["error"]) 
+            self._update_status("保存に失敗しました", STATUS_COLORS["error"])
             messagebox.showerror("保存エラー", f"ファイルを保存できませんでした: {exc}")
 
-    def analyze_file_sync(self):
-        asyncio.run(self._analyze_file())
+    def analyze_file_async(self):
+        """Run analysis in a worker thread to keep the GUI responsive."""
+        threading.Thread(
+            target=lambda: asyncio.run(self._analyze_file()), daemon=True
+        ).start()
 
     async def _analyze_file(self):
         if self.df is None or "投稿内容" not in self.df.columns:
-            self.view.update_status(
+            self._update_status(
                 "「投稿内容」列が見つかりません", STATUS_COLORS["error"]
             )
             return
-        self.view.enable_buttons(False)
+        self._enable_buttons(False)
         total_rows = len(self.df)
         category_flags = {name: [] for name in CATEGORY_NAMES}
         category_scores = {name: [] for name in CATEGORY_NAMES}
@@ -88,8 +107,8 @@ class ModerationController:
             ag_reasons.append(ag_res.reason)
 
             progress = (idx + 1) / total_rows
-            self.view.update_progress(progress)
-            self.view.update_status(f"分析中... {idx + 1}/{total_rows}")
+            self._update_progress(progress)
+            self._update_status(f"分析中... {idx + 1}/{total_rows}")
             await asyncio.sleep(0)  # allow UI update
 
         for name in CATEGORY_NAMES:
@@ -97,7 +116,7 @@ class ModerationController:
             self.df[f"{name}_score"] = category_scores[name]
         self.df["aggressiveness_score"] = ag_scores
         self.df["aggressiveness_reason"] = ag_reasons
-        self.view.update_status(
+        self._update_status(
             "分析が完了しました", STATUS_COLORS["success"]
         )
-        self.view.enable_buttons(True)
+        self._enable_buttons(True)

--- a/kougeki/view.py
+++ b/kougeki/view.py
@@ -17,6 +17,10 @@ class ModerationView(ctk.CTk):
         self.geometry("600x400")
         self.create_ui()
 
+    def call_in_main(self, func, *args, **kwargs) -> None:
+        """Execute ``func`` on the Tkinter main thread."""
+        self.after(0, lambda: func(*args, **kwargs))
+
     def create_ui(self):
         self.main_frame = ctk.CTkFrame(self)
         self.main_frame.pack(fill="both", expand=True, padx=20, pady=20)
@@ -48,7 +52,7 @@ class ModerationView(ctk.CTk):
         self.analyze_button = ctk.CTkButton(
             self.button_frame,
             text="分析開始",
-            command=self.controller.analyze_file_sync,
+            command=self.controller.analyze_file_async,
             width=200,
             height=40,
             state="disabled",


### PR DESCRIPTION
## Summary
- run moderation analysis in a worker thread so GUI stays responsive
- schedule all GUI updates on the main thread using `call_in_main`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd41f97f083339677ee65e58c21ff