### PR TITLE
Add aggregate aggressiveness scoring

### DIFF
--- a/kougeki/constants.py
+++ b/kougeki/constants.py
@@ -16,3 +16,11 @@ STATUS_COLORS = {
     "error": "red",
     "success": "green",
 }
+
+# Weights used for combining Moderation API scores with the LLM score
+# when calculating a single aggressiveness metric.
+AGGREGATE_WEIGHTS = {
+    "llm": 0.7,
+    "hate": 0.2,
+    "violence": 0.1,
+}

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -120,3 +120,18 @@ async def test_retry_decorator_failure(monkeypatch):
     with pytest.raises(RuntimeError):
         await always_fail()
     assert len(calls) == 2
+
+
+def test_aggregate_aggressiveness():
+    scores = services.ModerationScores(
+        hate=0.2,
+        hate_threatening=0,
+        self_harm=0,
+        sexual=0,
+        sexual_minors=0,
+        violence=0.3,
+        violence_graphic=0,
+    )
+    result = services.aggregate_aggressiveness(scores, 6, {"llm": 0.6, "hate": 0.3, "violence": 0.1})
+    assert isinstance(result, int)
+    assert 0 <= result <= 9


### PR DESCRIPTION
## Summary
- weight constants for score aggregation
- utility to combine moderation and LLM scores
- tests for new aggregation helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bd6f5af048333a789e9b895648db0