### PR TITLE
Add configurable weights

### DIFF
--- a/kougeki/config.py
+++ b/kougeki/config.py
@@ -11,6 +11,9 @@ class Settings(BaseSettings):
     moderation_model: str = "omni-moderation-latest"
     log_level: str = "INFO"
     log_file: str = "kougeki.log"
+    llm_weight: float = 0.7
+    hate_weight: float = 0.2
+    violence_weight: float = 0.1
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/kougeki/constants.py
+++ b/kougeki/constants.py
@@ -17,10 +17,14 @@ STATUS_COLORS = {
     "success": "green",
 }
 
-# Weights used for combining Moderation API scores with the LLM score
-# when calculating a single aggressiveness metric.
+from .config import settings
+
+# Default weights used for combining Moderation API scores with the LLM
+# score when calculating a single aggressiveness metric. Values come from
+# :class:`kougeki.config.Settings` so they can be configured via the
+# environment.
 AGGREGATE_WEIGHTS = {
-    "llm": 0.7,
-    "hate": 0.2,
-    "violence": 0.1,
+    "llm": settings.llm_weight,
+    "hate": settings.hate_weight,
+    "violence": settings.violence_weight,
 }

--- a/kougeki/services.py
+++ b/kougeki/services.py
@@ -14,7 +14,6 @@ from .models import (
     ModerationResult,
     ModerationScores,
 )
-from .constants import AGGREGATE_WEIGHTS
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +133,7 @@ async def get_aggressiveness_score(text: str) -> AggressivenessResult:
 def aggregate_aggressiveness(
     mod_scores: ModerationScores,
     llm_score: int | None,
-    weights: dict[str, float] = AGGREGATE_WEIGHTS,
+    weights: dict[str, float] | None = None,
 ) -> int | None:
     """Combine LLM and moderation scores into a single metric.
 
@@ -147,6 +146,7 @@ def aggregate_aggressiveness(
         function returns ``None``.
     weights:
         Mapping of ``"llm"``, ``"hate"`` and ``"violence"`` weight values.
+        If ``None`` the values from :data:`kougeki.config.settings` are used.
 
     Returns
     -------
@@ -157,6 +157,13 @@ def aggregate_aggressiveness(
 
     if llm_score is None:
         return None
+
+    if weights is None:
+        weights = {
+            "llm": settings.llm_weight,
+            "hate": settings.hate_weight,
+            "violence": settings.violence_weight,
+        }
 
     overall = (
         llm_score * weights.get("llm", 0)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -135,3 +135,20 @@ def test_aggregate_aggressiveness():
     result = services.aggregate_aggressiveness(scores, 6, {"llm": 0.6, "hate": 0.3, "violence": 0.1})
     assert isinstance(result, int)
     assert 0 <= result <= 9
+
+
+def test_aggregate_aggressiveness_from_settings(monkeypatch):
+    scores = services.ModerationScores(
+        hate=0.5,
+        hate_threatening=0,
+        self_harm=0,
+        sexual=0,
+        sexual_minors=0,
+        violence=0.5,
+        violence_graphic=0,
+    )
+    monkeypatch.setattr(services.settings, "llm_weight", 0.0)
+    monkeypatch.setattr(services.settings, "hate_weight", 0.0)
+    monkeypatch.setattr(services.settings, "violence_weight", 0.0)
+    result = services.aggregate_aggressiveness(scores, 7)
+    assert result == 0


### PR DESCRIPTION
## Summary
- allow customizing weighting factors through config settings
- default weights in constants now reference `settings`
- use settings in `aggregate_aggressiveness`
- test default weight behaviour

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4f7ee34c83339a78206db6ee91ad