### PR TITLE
Add configurable chat temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Moderation scores are combined with the LLM prediction to create an
 
 Run `python main.py` to start the GUI.
 
+### Environment variables
+
+The application reads the following optional settings from `.env`:
+
+- `CHAT_TEMPERATURE` (default `0.1`)
+- `LOG_LEVEL`
+- `LOG_FILE`
+
 ## Running Tests
 
 Install test dependencies and execute the suite:

--- a/kougeki/config.py
+++ b/kougeki/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     moderation_model: str = "omni-moderation-latest"
     log_level: str = "INFO"
     log_file: str = "kougeki.log"
+    chat_temperature: float = 0.1
     llm_weight: float = 0.7
     hate_weight: float = 0.2
     violence_weight: float = 0.1

--- a/kougeki/services.py
+++ b/kougeki/services.py
@@ -137,7 +137,7 @@ async def get_aggressiveness_score(text: str) -> AggressivenessResult:
             },
             {"role": "user", "content": prompt},
         ],
-        temperature=0,
+        temperature=settings.chat_temperature,
         top_p=0.9,
         response_format={"type": "json_object"},
     )


### PR DESCRIPTION
## Summary
- allow customizing chat completion temperature via new `CHAT_TEMPERATURE` setting
- use the setting in the OpenAI chat call
- document optional environment variables in README

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ddd0584c88333b85af93dd970c629